### PR TITLE
Fix HTMLParser.unescape method remove from python 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U pytest pytest-cov
+          python -m pip install -U pytest pytest-cov mock
 
       - name: Tests
         shell: bash

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -1,0 +1,55 @@
+# encoding: utf-8
+
+import json
+import re
+
+try:
+    import HTMLParser
+except ImportError:
+    import html.parser as HTMLParser
+
+from twitter.cmdline import (
+    replaceInStatus,
+    StatusFormatter,
+    VerboseStatusFormatter,
+    JSONStatusFormatter,
+)
+
+
+status = {
+    "created_at": "sun dec 20 18:33:30 +0000 2020",
+    "user": {"screen_name": "myusername", "location": "Paris"},
+    "text": "test &amp; test",
+}
+
+
+def test_replaceInStatus():
+    status = "my&amp;status @twitter #tag"
+    assert replaceInStatus(status) == "my&status @twitter #tag"
+
+
+def test_StatusFormatter():
+    test_status = StatusFormatter()
+    options = {"timestamp": True, "datestamp": False}
+    assert test_status(status, options) == "20:33:30 @myusername test & test"
+
+
+def test_VerboseStatusFormatter():
+    test_status = VerboseStatusFormatter()
+    options = {"timestamp": True, "datestamp": False}
+    assert (
+        test_status(status, options)
+        == "-- myusername (Paris) on sun dec 20 18:33:30 +0000 2020\ntest & test\n"
+    )
+
+
+def test_JSONStatusFormatter():
+    test_status = JSONStatusFormatter()
+    options = {"timestamp": True, "datestamp": False}
+    assert test_status(status, options) == json.dumps(
+        {
+            "created_at": "sun dec 20 18:33:30 +0000 2020",
+            "user": {"screen_name": "myusername", "location": "Paris"},
+            "text": "test & test",
+        }
+    )

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -2,6 +2,8 @@
 
 import json
 import re
+import unittest
+from mock import patch
 
 try:
     import HTMLParser
@@ -16,40 +18,39 @@ from twitter.cmdline import (
 )
 
 
-status = {
-    "created_at": "sun dec 20 18:33:30 +0000 2020",
-    "user": {"screen_name": "myusername", "location": "Paris"},
-    "text": "test &amp; test",
-}
+class TestCmdLine(unittest.TestCase):
 
+    status = {
+        "created_at": "sun dec 20 18:33:30 +0000 2020",
+        "user": {"screen_name": "myusername", "location": "Paris, France"},
+        "text": "test &amp; test",
+    }
 
-def test_replaceInStatus():
-    status = "my&amp;status @twitter #tag"
-    assert replaceInStatus(status) == "my&status @twitter #tag"
+    def test_replaceInStatus(self):
+        status = "my&amp;status @twitter #tag"
+        assert replaceInStatus(status) == "my&status @twitter #tag"
 
+    @patch("twitter.cmdline.get_time_string", return_value="18:33:30 ")
+    def test_StatusFormatter(self, mock_get_time_string):
+        test_status = StatusFormatter()
+        options = {"timestamp": True, "datestamp": False}
+        assert test_status(self.status, options) == "18:33:30 @myusername test & test"
 
-def test_StatusFormatter():
-    test_status = StatusFormatter()
-    options = {"timestamp": True, "datestamp": False}
-    assert test_status(status, options) == "20:33:30 @myusername test & test"
+    def test_VerboseStatusFormatter(self):
+        test_status = VerboseStatusFormatter()
+        options = {"timestamp": True, "datestamp": False}
+        assert (
+            test_status(self.status, options)
+            == "-- myusername (Paris, France) on sun dec 20 18:33:30 +0000 2020\ntest & test\n"
+        )
 
-
-def test_VerboseStatusFormatter():
-    test_status = VerboseStatusFormatter()
-    options = {"timestamp": True, "datestamp": False}
-    assert (
-        test_status(status, options)
-        == "-- myusername (Paris) on sun dec 20 18:33:30 +0000 2020\ntest & test\n"
-    )
-
-
-def test_JSONStatusFormatter():
-    test_status = JSONStatusFormatter()
-    options = {"timestamp": True, "datestamp": False}
-    assert test_status(status, options) == json.dumps(
-        {
-            "created_at": "sun dec 20 18:33:30 +0000 2020",
-            "user": {"screen_name": "myusername", "location": "Paris"},
-            "text": "test & test",
-        }
-    )
+    def test_JSONStatusFormatter(self):
+        test_status = JSONStatusFormatter()
+        options = {"timestamp": True, "datestamp": False}
+        assert test_status(self.status, options) == json.dumps(
+            {
+                "created_at": "sun dec 20 18:33:30 +0000 2020",
+                "user": {"screen_name": "myusername", "location": "Paris, France"},
+                "text": "test & test",
+            }
+        )

--- a/twitter/cmdline.py
+++ b/twitter/cmdline.py
@@ -125,7 +125,12 @@ OPTIONS = {
     'force-ansi': False,
 }
 
-gHtmlParser = HTMLParser.HTMLParser()
+try:
+    unescape = HTMLParser.HTMLParser().unescape
+except AttributeError:
+    import html
+    unescape = html.unescape
+
 hashtagRe = re.compile(r'(?P<hashtag>#\S+)')
 profileRe = re.compile(r'(?P<profile>\@\S+)')
 ansiFormatter = ansi.AnsiCmd(False)
@@ -207,7 +212,7 @@ def reRepl(m):
 
 
 def replaceInStatus(status):
-    txt = gHtmlParser.unescape(status)
+    txt = unescape(status)
     txt = re.sub(hashtagRe, reRepl, txt)
     txt = re.sub(profileRe, reRepl, txt)
     return txt
@@ -226,7 +231,7 @@ class StatusFormatter(object):
         return ("%s@%s %s" % (
             get_time_string(status, options),
             status['user']['screen_name'],
-            gHtmlParser.unescape(correctRTStatus(status))))
+            unescape(correctRTStatus(status))))
 
 
 class AnsiStatusFormatter(object):
@@ -248,12 +253,12 @@ class VerboseStatusFormatter(object):
             status['user']['screen_name'],
             status['user']['location'],
             status['created_at'],
-            gHtmlParser.unescape(correctRTStatus(status))))
+            unescape(correctRTStatus(status))))
 
 
 class JSONStatusFormatter(object):
     def __call__(self, status, options):
-        status['text'] = gHtmlParser.unescape(status['text'])
+        status['text'] = unescape(status['text'])
         return json.dumps(status)
 
 


### PR DESCRIPTION
I tried to fix this, but I'm not quit sure it's the best way to do it...

Should fix the issue #423 I mentionned.