### PR TITLE
Deploy to TestPyPI on merges to master, to PyPI for releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    if: github.repository == 'python-twitter-tools/twitter'
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: deploy-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            deploy-
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U setuptools twine wheel
+
+      - name: Build package
+        run: |
+          python setup.py --version
+          python setup.py sdist --format=gztar bdist_wheel
+          twine check dist/*
+
+      - name: Publish package to PyPI
+        if: github.event.action == 'published'
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+
+      - name: Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.test_pypi_password }}
+          repository_url: https://test.pypi.org/legacy/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,6 @@
-include AUTHORS
-include LICENSE
-include README
+prune .github
+prune tests
+prune utils
+exclude .coveragerc
+exclude .gitignore
+exclude README.md

--- a/README
+++ b/README
@@ -1,8 +1,8 @@
 Python Twitter Tools
 ====================
 
-[![Tests](https://github.com/sixohsix/twitter/workflows/Tests/badge.svg)](https://github.com/sixohsix/twitter/actions)
-[![Coverage Status](https://coveralls.io/repos/github/sixohsix/twitter/badge.svg?branch=master)](https://coveralls.io/github/sixohsix/twitter?branch=master)
+[![Tests](https://github.com/python-twitter-tools/twitter/workflows/Tests/badge.svg)](https://github.com/python-twitter-tools/twitter/actions)
+[![Coverage Status](https://coveralls.io/repos/github/python-twitter-tools/twitter/badge.svg?branch=master)](https://coveralls.io/github/python-twitter-tools/twitter?branch=master)
 
 The Minimalist Twitter API for Python is a Python API for Twitter,
 everyone's favorite Web 2.0 Facebook-style status updater for people

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,10 @@
+# Release Checklist
+
+- [ ] Get master to the appropriate code release state.
+
+- [ ] Publish release with new tag like `twitter-x.y.z`:
+      https://github.com/python-twitter-tools/twitter/releases/new
+
+- [ ] Check the tagged
+      [GitHub Actions build](https://github.com/python-twitter-tools/twitter/actions?query=workflow%3ADeploy)
+      has deployed to [PyPI](https://pypi.org/project/twitter/#history)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[egg_info]
-#tag_build = dev
-tag_svn_revision = false
 [wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,13 @@ from setuptools import setup, find_packages
 with open("README") as f:
     long_description = f.read()
 
-version = '1.18.0'
+
+def local_scheme(version):
+    """Skip the local version (eg. +xyz of 0.6.1.dev4+gdf99fe2)
+    to be able to upload to Test PyPI"""
+    return ""
 
 setup(name='twitter',
-      version=version,
       description="An API and command-line toolset for Twitter (twitter.com)",
       long_description=long_description,
       long_description_content_type="text/markdown",
@@ -40,6 +43,8 @@ setup(name='twitter',
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
       include_package_data=True,
       zip_safe=True,
+      use_scm_version={"local_scheme": local_scheme},
+      setup_requires=["setuptools_scm"],
       entry_points="""
       # -*- Entry points: -*-
       [console_scripts]


### PR DESCRIPTION
Fixes https://github.com/python-twitter-tools/twitter/issues/422.

This sets up GitHub Actions/PyPI API tokens to:

* Deploy to TestPyPI on merge to master, to make sure the release mechanism is working smoothly and avoid surprises on release day
* Deploy to production PyPI for GitHub releases/tags

I'll annotate on the files in the diff to explain what each bit does. I also added a release checklist `RELEASING.md` as a handy reference to check when releasing.

This also updates the README badges to link to new organisation URLs.
