### PR TITLE
Deploy: Fix deprecation warning with pypa/gh-action-pypi-publish@master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -45,7 +45,7 @@ jobs:
           password: ${{ secrets.pypi_password }}
 
       - name: Publish package to TestPyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.test_pypi_password }}


### PR DESCRIPTION
https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset- says:

> The `master` branch version has been sunset. Please, change the GitHub Action version you use from `master` to `release/v1` or use an exact tag, or a full Git commit SHA.

And there are warnings for example at https://github.com/python-twitter-tools/twitter/actions/runs/3051809874

So let's use `pypa/gh-action-pypi-publish@release/v1`

Also bump `actions/checkout` whilst we're here.
