### PR TITLE
Test CI on Windows and macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,17 +12,20 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
+        # Include 2.7, lowest and highest 3.x, plus any dev versions
         python-version: [
             "2.7",
             "3.6",
             "3.7",
-            "3.8",
-            "3.9",
             "3.10",
             "3.11-dev",
             "pypy2.7",
         ]
         os: [ubuntu-latest]
+        include:
+          # Test Windows and macOS on other 3.x versions
+          - { python-version: "3.8", os: "windows-latest" }
+          - { python-version: "3.9", os: "macos-latest" }
 
     steps:
       - uses: actions/checkout@v3
@@ -45,7 +48,9 @@ jobs:
         run: |
           pytest --cov twitter --cov tests --cov-report=xml
 
+        # Linux only
       - name: Coveralls
+        if: matrix.is == 'ubuntu-latest'
         uses: AndreMiras/coveralls-python-action@develop
         with:
           parallel: true


### PR DESCRIPTION
Follow on from https://github.com/python-twitter-tools/twitter/pull/451#issuecomment-1246747905.

~Drop support for Python 3.6, end-of-life on 2021-12-23.~ Moved to #454.

On the CI, test Ubuntu with:

* Python 2.7 (CPython and PyPy)
* the lowest and highest 3.x versions
* Any dev versions

And also test Windows on 3.8 and macOS 3.9.