### PR TITLE
Replace 3.11-dev with 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 env:
   FORCE_COLOR: 1
@@ -18,7 +18,7 @@ jobs:
             "3.8",
             "3.9",
             "3.10",
-            "3.11-dev",
+            "3.11",
             "pypy2.7",
         ]
         os: [ubuntu-latest]


### PR DESCRIPTION
Python 3.11 is now out!

https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291

Also add `workflow_dispatch`, which gives us a button on the Actions page to manually trigger a build, like Travis CI has, just in case we'll need it.